### PR TITLE
Allow separate channels per classifier

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changes
 =======
 
+Version 1.2.0
+-------------
+
+**Upcoming**
+
+* Made ``OdinEmbeddedClassifierContainer`` require a list of lists for channel
+  specifications.
+
+
 Version 1.1.0
 -------------
 

--- a/classiflib/__init__.py
+++ b/classiflib/__init__.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 import logging
 
-__version__ = '1.1.0'
+__version__ = '1.2.dev0'
 version_info = namedtuple("VersionInfo", "major,minor,patch")(*__version__.split('.'))
 
 logger = logging.getLogger(__name__)

--- a/classiflib/dtypes.py
+++ b/classiflib/dtypes.py
@@ -73,7 +73,9 @@ class OdinEmbeddedMeta(Schema):
     """OdinEmbeddedMeta info that can be stored in a schema bundle."""
     subject = traits.CBytes(desc='subject code', maxlen=16)
     timestamp = traits.CFloat(desc='unix timestamp')
-    num_channels = traits.CInt(desc='number of channels')
+    num_channels = traits.Array(dtype=int,
+                                desc=('number of channels for each classifier '
+                                      '(or in general for record-only mode)'))
     num_classifiers = traits.CInt(desc='number of classifiers')
 
 

--- a/classiflib/test/test_container.py
+++ b/classiflib/test/test_container.py
@@ -168,7 +168,7 @@ class TestOdinEmbeddedContainer:
             OdinEmbeddedClassifierContainer(channels, classifiers)
 
         # within limits
-        channels.pop()
+        channels = [self.make_channels(subject, 32)]
         classifiers.pop()
         oecc = OdinEmbeddedClassifierContainer(channels, classifiers)
 
@@ -180,10 +180,13 @@ class TestOdinEmbeddedContainer:
         for i, cl in enumerate(classifiers):
             assert cl == oecc.classifiers[i]
 
-    def test_save_load(self, tmpdir):
+    @pytest.mark.parametrize('num_classifiers', [0, 1, 2])
+    def test_save_load(self, tmpdir, num_classifiers):
         subject = b'R0001X'
-        channels = self.make_channels(subject, 32)
-        classifiers = self.make_classifiers(subject, 1)
+
+        num_channelsets = num_classifiers if num_classifiers > 0 else 1
+        channels = [self.make_channels(subject, 32) for _ in range(num_channelsets)]
+        classifiers = self.make_classifiers(subject, num_classifiers)
         filename = str(tmpdir.join('classifier.zip'))
         cc = OdinEmbeddedClassifierContainer(channels, classifiers)
         cc.save(filename)

--- a/classiflib/test/test_dtypes.py
+++ b/classiflib/test/test_dtypes.py
@@ -1,3 +1,5 @@
+import pytest
+
 from classiflib.dtypes import *
 
 
@@ -19,20 +21,21 @@ def test_make_timing_window():
     assert window.buffer == 1.365
 
 
-def test_oe_classifier():
-    OdinEmbeddedClassifier(
-        averaging_interval=1366,
-        refractory_period=1000,
-        threshold=1,
-        waveform_name=b'wvfm1',
-        stim_channel_name=b'LTC1LTC2'
-    )
+@pytest.mark.odin_embedded
+class TestEmbeddedDtypes:
+    def test_oe_classifier(self):
+        OdinEmbeddedClassifier(
+            averaging_interval=1366,
+            refractory_period=1000,
+            threshold=1,
+            waveform_name=b'wvfm1',
+            stim_channel_name=b'LTC1LTC2'
+        )
 
-
-def test_oe_channel():
-    OdinEmbeddedChannel(
-        label=b'LA1LA2',
-        means=np.linspace(0, 8, 8, dtype=np.int16),
-        sigmas=np.linspace(0, 8, 8, dtype=np.int16),
-        weights=np.random.random((8,))
-    )
+    def test_oe_channel(self):
+        OdinEmbeddedChannel(
+            label=b'LA1LA2',
+            means=np.linspace(0, 8, 8, dtype=np.int16),
+            sigmas=np.linspace(0, 8, 8, dtype=np.int16),
+            weights=np.random.random((8,))
+        )


### PR DESCRIPTION
Also support record-only embedded mode (i.e., include one set of channels even without classifiers).